### PR TITLE
update requirements to address CVE-2019-10906

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Click==7.0
 Flask==1.0.2
 Flask-RESTful==0.3.7
 itsdangerous==1.1.0
-Jinja2==2.10
+Jinja2~>2.10
 MarkupSafe==1.1.0
 pytz==2018.9
 redis==3.2.0


### PR DESCRIPTION
This PR updates requirements to avoid a vulnerability in the Jinja2 package. Is this code deployed anywhere? 

--timball