### PR TITLE
bump werkzeug version 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ pytz==2018.9
 redis==3.2.0
 short-url==1.2.2
 six==1.12.0
-Werkzeug==0.14.1
+Werkzeug>=0.15.3


### PR DESCRIPTION
there's a HIGH SEVERITY CVE for werkzeug

CVE-2019-14806

This is untested but should merge fine. Is this code deployed anywhere? do we have a survey of what code is deployed where? 

--timball